### PR TITLE
Use From field to determine email originator domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
-    "@types/aws-lambda": "^8.10.39",
+    "@types/aws-lambda": "^8.10.46",
     "@types/mailparser": "^2.7.0",
     "@types/node": "^13.7.7",
     "@typescript-eslint/eslint-plugin": "^2.17.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const handler = async (event: SESEvent): Promise<string> => {
   const origOrg = origHeaders[0].value;
 
   const getS3Key = (fileName: string): string =>
-    `${timestamp.replace(/-/g, "/")}_${origOrg}/${fileName}`;
+    `${timestamp.replace(/-/g, "/").replace(/:/g, "-")}_${origOrg}/${fileName}`;
 
   console.log(
     `Getting raw email ${ses.mail.messageId} from ${INBOX_S3_BUCKET_NAME} for ${origOrg}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,18 +26,31 @@ export const handler = async (event: SESEvent): Promise<string> => {
   const { timestamp } = ses.mail;
 
   const { headers }: { headers: Header[] } = ses.mail;
-  const origHeaders = headers.filter(h => h.name === "X-OriginatorOrg");
+  const origHeaders = headers.filter(h => h.name === "From");
 
   if (origHeaders.length == 0 || !origHeaders[0].value) {
-    return "Error: X-OriginatorOrg missing from email.";
+    const err = "Error: 'From' header missing from email.";
+    console.log(err);
+    console.log(JSON.stringify(ses, null, 2));
+    return err;
   }
-  const origOrg = origHeaders[0].value;
+  const originatorMatch = origHeaders[0].value.match(/@([\w\.]+)/);
+  if (!originatorMatch || originatorMatch?.length < 2) {
+    const err = "Error: Could not determine domain part of email.";
+    console.log(err);
+    console.log(JSON.stringify(ses, null, 2));
+    return err;
+  }
+
+  const originator = originatorMatch[1];
 
   const getS3Key = (fileName: string): string =>
-    `${timestamp.replace(/-/g, "/").replace(/:/g, "-")}_${origOrg}/${fileName}`;
+    `${timestamp
+      .replace(/-/g, "/")
+      .replace(/:/g, "-")}_${originator}/${fileName}`;
 
   console.log(
-    `Getting raw email ${ses.mail.messageId} from ${INBOX_S3_BUCKET_NAME} for ${origOrg}`
+    `Getting raw email ${ses.mail.messageId} from ${INBOX_S3_BUCKET_NAME} for ${originator}`
   );
   try {
     rawEmailResponse = await s3

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,7 +902,7 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@types/aws-lambda@^8.10.39":
+"@types/aws-lambda@^8.10.46":
   version "8.10.46"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.46.tgz#3246348cdc15921bd065966109fc1c6f6d5cfd96"
   integrity sha512-88E4Hlypo3AE40wslm7N4n09lCIJwgYJm5wsaA3/Vib1xqjC/ANePTaPRpPdj9NzBSpw7Tgon58qGMYEArx4oA==


### PR DESCRIPTION
Update to just use the 'From' field in email to determine sender domain, rather than x-originator org which is not reliably set.  